### PR TITLE
Boyscout/fix specs

### DIFF
--- a/app/controllers/CFPAdmin.scala
+++ b/app/controllers/CFPAdmin.scala
@@ -475,7 +475,6 @@ object CFPAdmin extends SecureCFPController {
               if(showQuickiesAndBof){
                 p==null
               }else{
-                p.talkType==ConferenceDescriptor.ConferenceProposalTypes.BOF ||
                 p.talkType==ConferenceDescriptor.ConferenceProposalTypes.QUICK
               }
           }

--- a/app/models/ApprovedProposal.scala
+++ b/app/models/ApprovedProposal.scala
@@ -38,13 +38,10 @@ object ApprovedProposal {
 
   val getTotal: Map[String, Int] = Map(
     ("conf.label", ConferenceProposalConfigurations.CONF.slotsCount)
-    , ("uni.label", ConferenceProposalConfigurations.UNI.slotsCount)
     , ("tia.label", ConferenceProposalConfigurations.TIA.slotsCount)
     , ("lab.label", ConferenceProposalConfigurations.LAB.slotsCount)
     , ("quick.label", ConferenceProposalConfigurations.QUICK.slotsCount)
-    , ("bof.label", ConferenceProposalConfigurations.BOF.slotsCount)
     , ("key.label", ConferenceProposalConfigurations.KEY.slotsCount)
-    , ("ignite.label", ConferenceProposalConfigurations.IGNITE.slotsCount)
     , ("other.label", ConferenceProposalConfigurations.OTHER.slotsCount)
   )
 

--- a/app/models/ConferenceDescriptor.scala
+++ b/app/models/ConferenceDescriptor.scala
@@ -115,19 +115,13 @@ object ConferenceDescriptor {
   object ConferenceProposalTypes {
     val CONF = ProposalType(id = "conf", label = "conf.label")
 
-    val UNI = ProposalType(id = "uni", label = "uni.label")
-
     val TIA = ProposalType(id = "tia", label = "tia.label")
 
     val LAB = ProposalType(id = "lab", label = "lab.label")
 
     val QUICK = ProposalType(id = "quick", label = "quick.label")
 
-    val BOF = ProposalType(id = "bof", label = "bof.label")
-
     val KEY = ProposalType(id = "key", label = "key.label")
-
-    val IGNITE = ProposalType(id = "ignite", label = "ignite.label")
 
     val OTHER = ProposalType(id = "other", label = "other.label")
 
@@ -148,20 +142,14 @@ object ConferenceDescriptor {
   object ConferenceProposalConfigurations {
     val CONF = ProposalConfiguration(id = "conf", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.CONF.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "icon-microphone",
       chosablePreferredDay = true)
-    val UNI = ProposalConfiguration(id = "uni", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.UNI.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "icon-laptop",
-      chosablePreferredDay = true)
     val TIA = ProposalConfiguration(id = "tia", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.TIA.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "icon-legal",
       chosablePreferredDay = true)
     val LAB = ProposalConfiguration(id = "lab", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.LAB.id)), givesSpeakerFreeEntrance = true, freeEntranceDisplayed = true, htmlClass = "icon-beaker",
       chosablePreferredDay = true)
     val QUICK = ProposalConfiguration(id = "quick", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.QUICK.id)), givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false, htmlClass = "icon-fast-forward",
       chosablePreferredDay = true)
-    val BOF = ProposalConfiguration(id = "bof", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.BOF.id)), givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false, htmlClass = "icon-group",
-      chosablePreferredDay = false)
     val KEY = ProposalConfiguration(id = "key", slotsCount = 7, givesSpeakerFreeEntrance = true, freeEntranceDisplayed = false, htmlClass = "icon-microphone",
       chosablePreferredDay = true)
-    val IGNITE = ProposalConfiguration(id = "ignite", slotsCount = ConferenceSlots.all.count(_.name.equals(ConferenceProposalTypes.IGNITE.id)), givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false, htmlClass = "icon-microphone",
-      chosablePreferredDay = false)
     val OTHER = ProposalConfiguration(id = "other", slotsCount = 5, givesSpeakerFreeEntrance = false, freeEntranceDisplayed = false, htmlClass = "icon-microphone",
       hiddenInCombo = true, chosablePreferredDay = false)
 

--- a/app/views/Attic/atticHome.scala.html
+++ b/app/views/Attic/atticHome.scala.html
@@ -44,10 +44,6 @@
                         <button type="submit" class="btn btn-primary">Prune draft proposals</button>
                     </form>
                     <form action="@routes.Attic.doArchive()" method="POST">
-                        <input type="hidden" name="proposalType" value="@ConferenceDescriptor.ConferenceProposalTypes.UNI.id"/>
-                        <button type="submit" class="btn btn-primary">Archive all University</button>
-                    </form>
-                    <form action="@routes.Attic.doArchive()" method="POST">
                         <input type="hidden" name="proposalType" value="@ConferenceDescriptor.ConferenceProposalTypes.KEY.id"/>
                         <button type="submit" class="btn btn-primary">Archive all Keynotes</button>
                     </form>
@@ -64,20 +60,12 @@
                         <button type="submit" class="btn btn-primary">Archive all Quickies</button>
                     </form>
                     <form action="@routes.Attic.doArchive()" method="POST">
-                        <input type="hidden" name="proposalType" value="@ConferenceDescriptor.ConferenceProposalTypes.BOF.id"/>
-                        <button type="submit" class="btn btn-primary">Archive all BOF</button>
-                    </form>
-                    <form action="@routes.Attic.doArchive()" method="POST">
                         <input type="hidden" name="proposalType" value="@ConferenceDescriptor.ConferenceProposalTypes.LAB.id"/>
                         <button type="submit" class="btn btn-primary">Archive all Labs</button>
                     </form>
                     <form action="@routes.Attic.doArchive()" method="POST">
                         <input type="hidden" name="proposalType" value="@ConferenceDescriptor.ConferenceProposalTypes.OTHER.id"/>
                         <button type="submit" class="btn btn-primary">Archive all other talks</button>
-                    </form>
-                    <form action="@routes.Attic.doArchive()" method="POST">
-                        <input type="hidden" name="proposalType" value="@ConferenceDescriptor.ConferenceProposalTypes.IGNITE.id"/>
-                        <button type="submit" class="btn btn-primary">Archive all Ignite</button>
                     </form>
 
                     <hr>

--- a/app/views/CFPAdmin/allSpeakersWithAcceptedTalksForExport.scala.html
+++ b/app/views/CFPAdmin/allSpeakersWithAcceptedTalksForExport.scala.html
@@ -38,14 +38,11 @@
             <th>First name</th>
             <th>Email</th>
             <th>Company</th>
-            <th>Uni ?</th>
             <th>Conf ?</th>
             <th>Keynote ?</th>
             <th>Lab ?</th>
             <th>Tia ?</th>
-            <th>Ignite ?</th>
             <th>Quickie ?</th>
-            <th>BOF ?</th>
             <th>Other ?</th>
         </tr>
     </thead>
@@ -58,14 +55,11 @@
     <td>@speaker.firstName</td>
     <td>@speaker.email</td>
     <td>@speaker.company</td>
-    <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.UNI) </td>
     <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.CONF)  </td>
     <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.KEY)  </td>
     <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.LAB)  </td>
     <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.TIA)  </td>
-    <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.IGNITE)  </td>
     <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.QUICK)  </td>
-    <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.BOF)  </td>
     <td> @tags.renderSpeakerPresents(props,ConferenceDescriptor.ConferenceProposalTypes.OTHER)  </td>
     </tr>
 }

--- a/app/views/Publisher/showMonday.scala.html
+++ b/app/views/Publisher/showMonday.scala.html
@@ -46,29 +46,6 @@
                     <td><em>Exhibition set-up</em></td>
 
                     <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-
-                    </td>
-
-                    <td class="room">
                         <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.LAB.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
                             Hands-on Labs</a>
                     </td>
@@ -97,30 +74,6 @@
                     </th>
 
                     <td><em>Exhibition set-up</em></td>
-
-                    <td class="room">
-
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.UNI.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            Universities</a>
-
-                    </td>
 
                     <td class="room">
                         <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.LAB.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
@@ -263,16 +216,6 @@
 
                     <td colspan="4"> </td>
 
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.BOF.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            BOFs</a>
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.BOF.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            BOFs</a>
-                    </td>
-
                 </tr>
 
                 <tr>
@@ -283,16 +226,6 @@
 
                     <td colspan="4"> </td>
 
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.BOF.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            BOFs</a>
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.BOF.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            BOFs</a>
-                    </td>
-
                 </tr>
 
                 <tr>
@@ -302,16 +235,6 @@
                     <td></td>
 
                     <td colspan="4"> </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.BOF.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            BOFs</a>
-                    </td>
-
-                    <td class="room">
-                        <a href="@routes.SchedullingController.getPublishedSchedule(ConferenceDescriptor.ConferenceProposalTypes.BOF.id, Some("monday"))" class="btn btn-primary btn-sm"><i class="icon-laptop"></i>
-                            BOFs</a>
-                    </td>
 
 
                 </tr>

--- a/test/models/ApprovedProposalSpecs.scala
+++ b/test/models/ApprovedProposalSpecs.scala
@@ -40,7 +40,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
   val appWithTestRedis = () => FakeApplication(additionalConfiguration = testRedis)
 
   "ApprovedProposal" should {
-    "return correct total with countApproved for a BOF" in new WithApplication(app = appWithTestRedis()) {
+    "return correct total with countApproved for a CONF" in new WithApplication(app = appWithTestRedis()) {
 
       // WARN : flush the DB, but on Database = 1
       Redis.pool.withClient {
@@ -50,7 +50,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // GIVEN
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary", "private message", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = Some(true))
@@ -62,11 +62,11 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // THEN
       ApprovedProposal.countApproved("all") mustEqual 1
-      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.BOF.id) mustEqual 1
-      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.CONF.id) mustEqual 0
+      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.CONF.id) mustEqual 1
+      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.LAB.id) mustEqual 0
     }
 
-    "return the updated total when proposal type is updated from BOF to CONF, fix bug 159" in new WithApplication(app = appWithTestRedis()) {
+    "return the updated total when proposal type is updated from CONF to LAB, fix bug 159" in new WithApplication(app = appWithTestRedis()) {
 
       // WARN : flush the DB, but on Database = 1
       Redis.pool.withClient {
@@ -76,7 +76,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // GIVEN
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary", "private message", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -85,16 +85,16 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // WHEN
       ApprovedProposal.approve(proposal)
-      val proposal2 = proposal.copy(talkType = ConferenceDescriptor.ConferenceProposalTypes.CONF)
+      val proposal2 = proposal.copy(talkType = ConferenceDescriptor.ConferenceProposalTypes.LAB)
       Proposal.save("test", proposal2, ProposalState.SUBMITTED)
 
       // THEN
       ApprovedProposal.countApproved("all") mustEqual 1
-      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.BOF.id) mustEqual 0
-      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.CONF.id) mustEqual 1
+      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.CONF.id) mustEqual 0
+      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.LAB.id) mustEqual 1
     }
 
-    "return the updated total when a refused proposal type is updated from BOF to CONF" in new WithApplication(app = appWithTestRedis()) {
+    "return the updated total when a refused proposal type is updated from CONF to LAB" in new WithApplication(app = appWithTestRedis()) {
 
       // WARN : flush the DB, but on Database = 1
       Redis.pool.withClient {
@@ -104,7 +104,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // GIVEN
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -118,7 +118,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // THEN
       ApprovedProposal.countRefused("all") mustEqual 1
-      ApprovedProposal.countRefused(ConferenceDescriptor.ConferenceProposalTypes.BOF.id) mustEqual 0
+      ApprovedProposal.countRefused(ConferenceDescriptor.ConferenceProposalTypes.CONF.id) mustEqual 0
       ApprovedProposal.countRefused(ConferenceDescriptor.ConferenceProposalTypes.LAB.id) mustEqual 1
     }
 
@@ -132,7 +132,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // GIVEN
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -146,7 +146,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
 
       // THEN
       ApprovedProposal.countApproved("all") mustEqual 0
-      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.BOF.id) mustEqual 0
+      ApprovedProposal.countApproved(ConferenceDescriptor.ConferenceProposalTypes.CONF.id) mustEqual 0
     }
 
     "decrease total refused when a refused proposal is deleted" in new WithApplication(app = appWithTestRedis()) {
@@ -188,7 +188,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2",
         None,
         Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -216,7 +216,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2",
         Some("secondarySpeaker"),
         Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -244,7 +244,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2",
         None,
         List("someOtherSpeaker"),
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -271,7 +271,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2",
         None,
         Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -301,7 +301,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2",
         Some("secondarySpeaker"),
         Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)
@@ -331,7 +331,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2",
         Some("secondarySpeaker"),
         List("firstThirdSpeaker"),
-        ConferenceDescriptor.ConferenceProposalTypes.BOF.id,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
         ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
         userGroup = None)

--- a/test/models/ApprovedProposalSpecs.scala
+++ b/test/models/ApprovedProposalSpecs.scala
@@ -23,8 +23,10 @@
 
 package models
 
+import java.util.UUID
+
 import library.Redis
-import play.api.test.{WithApplication, FakeApplication, PlaySpecification}
+import play.api.test.{FakeApplication, PlaySpecification, WithApplication}
 
 /**
  * Tests for approve/refuse service.
@@ -33,7 +35,7 @@ import play.api.test.{WithApplication, FakeApplication, PlaySpecification}
  */
 class ApprovedProposalSpecs extends PlaySpecification {
   // Use a different Redis Database than the PROD one
-  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6364", "redis.activeDatabase" -> 1)
+  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6363", "redis.activeDatabase" -> 1)
 
   // To avoid Play Cache Exception during tests, check this
   // https://groups.google.com/forum/#!topic/play-framework/PBIfeiwl5rU
@@ -49,11 +51,23 @@ class ApprovedProposalSpecs extends PlaySpecification {
       }
 
       // GIVEN
-      val proposal = Proposal.validateNewProposal(None, "fr", "test proposal", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
-        "audience level", "summary", "private message", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
-        userGroup = Some(true))
+      val proposal = Proposal(
+        UUID.randomUUID().toString,
+        "test event",
+        "fr",
+        "test proposal",
+        "no_main_speaker",
+        None,
+        Nil,
+        ConferenceDescriptor.ConferenceProposalTypes.CONF,
+        "audience level",
+        "summary",
+        "private message",
+        state = ProposalState.UNKNOWN,
+        track = Track.parse("java"),
+        demoLevel = Some("beginner"),
+        userGroup = Some(true)
+      )
 
       Proposal.save("test", proposal, ProposalState.SUBMITTED)
 
@@ -78,7 +92,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal", None, Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary", "private message", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("test", proposal, ProposalState.SUBMITTED)
@@ -106,7 +120,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2", None, Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("test", proposal, ProposalState.SUBMITTED)
@@ -134,7 +148,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2", None, Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("test", proposal, ProposalState.SUBMITTED)
@@ -161,7 +175,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
       val proposal = Proposal.validateNewProposal(None, "fr", "test proposal 2", None, Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("test", proposal, ProposalState.SUBMITTED)
@@ -190,7 +204,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
         Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("speaker1", proposal, ProposalState.SUBMITTED)
@@ -218,7 +232,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
         Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("speaker1", proposal, ProposalState.SUBMITTED)
@@ -246,7 +260,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
         List("someOtherSpeaker"),
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("speaker1", proposal, ProposalState.SUBMITTED)
@@ -273,7 +287,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
         Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("speaker1", proposal, ProposalState.SUBMITTED)
@@ -303,7 +317,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
         Nil,
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("speaker1", proposal, ProposalState.SUBMITTED)
@@ -333,7 +347,7 @@ class ApprovedProposalSpecs extends PlaySpecification {
         List("firstThirdSpeaker"),
         ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
         "audience level", "summary 2", "private message 2", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.JAVA.id, Some("beginner"),
+        Track.parse("java").id, Some("beginner"),
         userGroup = None)
 
       Proposal.save("speaker1", proposal, ProposalState.SUBMITTED)

--- a/test/models/ArchivedProposalSpecs.scala
+++ b/test/models/ArchivedProposalSpecs.scala
@@ -52,11 +52,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
 
       // GIVEN
       val uuidTest = "test_user"
-      val proposal = Proposal.validateNewProposal(None, "fr", "test proposal deleted", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
-        "audience level", "summary", "private message", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.UNKNOWN.id, Option("beginner"),
-        userGroup = None)
+      val proposal = testProposal(uuidTest, "test proposal deleted")
 
       val newProposalId = Proposal.save(uuidTest, proposal, ProposalState.DELETED)
 
@@ -85,11 +81,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
 
       // GIVEN
       val uuidTest = "test_user"
-      val proposal = Proposal.validateNewProposal(None, "fr", "test proposal deleted", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
-        "audience level", "summary", "private message", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.UNKNOWN.id, Option("beginner"),
-        userGroup = None)
+      val proposal = testProposal(uuidTest, "test proposal deleted")
 
       val newProposalId = Proposal.save(uuidTest, proposal, ProposalState.DRAFT)
 
@@ -120,12 +112,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
 
       // GIVEN a submitted proposal
       val uuidTest = "test_user"
-      val proposal = Proposal.validateNewProposal(None, "fr", "test proposal submitted", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
-        "audience level", "summary", "private message", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
-        Option("beginner"),
-        userGroup = None)
+      val proposal = testProposal(uuidTest, "test proposal submitted")
 
       val proposalId = Proposal.save(uuidTest, proposal, ProposalState.DRAFT)
       Proposal.submit(uuidTest, proposalId)
@@ -148,12 +135,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
 
       // GIVEN a submitted proposal
       val uuidTest = "test_user"
-      val proposal = Proposal.validateNewProposal(None, "fr", "test proposal accepted", None, Nil,
-        ConferenceDescriptor.ConferenceProposalTypes.CONF.id,
-        "audience level", "summary", "private message", sponsorTalk = false,
-        ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
-        Option("beginner"),
-        userGroup = None)
+      val proposal = testProposal(uuidTest, "test proposal accepted")
 
       val newProposalId = Proposal.save(uuidTest, proposal, ProposalState.DRAFT)
       Proposal.submit(uuidTest, newProposalId)
@@ -211,7 +193,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
       Review.allProposalsNotReviewed(reviewerUUID) mustEqual Nil
       Review.allProposalsWithNoVotes mustEqual Map.empty[String, Proposal]
       Review.allReviewersAndStats() mustEqual Nil
-      Review.allVotes() mustEqual Set.empty
+      Review.allVotes() mustEqual Map.empty
       Review.allVotesFor(proposalId) mustEqual Nil
       Review.allVotesFromUser(reviewerUUID) mustEqual Set.empty
       Review.bestReviewer() mustEqual None
@@ -303,7 +285,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
       Leaderboard.mostReviewed() mustEqual None
       Leaderboard.bestReviewer() mustEqual None
       Leaderboard.worstReviewer() mustEqual None
-      Leaderboard.lazyOnes() mustEqual Set.empty
+      Leaderboard.lazyOnes() mustEqual Map.empty
 
       Leaderboard.totalSubmittedByTrack() mustEqual Map.empty
       Leaderboard.totalSubmittedByType() mustEqual Map.empty
@@ -328,23 +310,28 @@ class ArchivedProposalSpecs extends PlaySpecification {
     }
   }
 
+  private def testProposal(proposalId: String, title: String) = Proposal(
+    proposalId,
+    "test event",
+    "fr",
+    title,
+    "no_main_speaker",
+    None,
+    Nil,
+    ConferenceDescriptor.ConferenceProposalTypes.CONF,
+    "audience level",
+    "summary",
+    "private message",
+    state = ProposalState.UNKNOWN,
+    track = Track.UNKNOWN,
+    demoLevel = Some("beginner"),
+    userGroup = None
+  )
+
   private def createATestProposalAndSubmitIt(speakerUUID: String): String = {
     // 3-
     val proposalId = RandomStringUtils.randomAlphabetic(8)
-    val someProposal = Proposal.validateNewProposal(
-      Some(proposalId),
-      "fr",
-      "some test Proposal",
-      None,
-      Nil,
-      ConferenceDescriptor.ConferenceProposalTypes.ALL.head.id,
-      "audience level",
-      "summary",
-      "private message",
-      sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.ALL.head.id,
-      Option("beginner"),
-      userGroup = None)
+    val someProposal = testProposal(proposalId, "some test Proposal")
 
     Proposal.save(speakerUUID, someProposal, ProposalState.DRAFT)
     // Submit the proposal
@@ -357,7 +344,7 @@ class ArchivedProposalSpecs extends PlaySpecification {
     val webuser = Webuser.createSpeaker(email, "John", "UnitTest")
     Webuser.saveAndValidateWebuser(webuser)
     val uuid =  webuser.uuid
-    val speaker =  Speaker.createSpeaker(email, "j", "b" , None,None,None,None,None,"john","q" )
+    val speaker =  Speaker.createSpeaker(uuid, email, "j","b" , None, None, None, None, None, "john", "q")
     Speaker.save(speaker)
     uuid
   }

--- a/test/models/InvitationSpecs.scala
+++ b/test/models/InvitationSpecs.scala
@@ -36,7 +36,7 @@ import play.api.test.{FakeApplication, WithApplication, PlaySpecification}
 class InvitationSpecs extends PlaySpecification with Debug {
 
   // Use a different Redis Database than the PROD one
-  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6364", "redis.activeDatabase" -> 1)
+  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6363", "redis.activeDatabase" -> 1)
 
   // To avoid Play Cache Exception during tests, check this
   // https://groups.google.com/forum/#!topic/play-framework/PBIfeiwl5rU

--- a/test/models/ProposalSpecs.scala
+++ b/test/models/ProposalSpecs.scala
@@ -27,6 +27,8 @@ import library.Redis
 import org.apache.commons.lang3.RandomStringUtils
 import play.api.test.{FakeApplication, PlaySpecification, WithApplication}
 
+import scala.collection.JavaConverters._
+
 /*
  * Play uses Specs2 for testing.
  *
@@ -39,7 +41,19 @@ class ProposalSpecs extends PlaySpecification {
     , "redis.port" -> "6363"
     , "redis.activeDatabase" -> 1
   )
-  val appWithTestRedis = FakeApplication(additionalConfiguration = testRedis)
+  val testTracks = Map(
+    "cfp.tracks" -> Seq(
+      Map(
+        "id" -> "java"
+        , "icon" -> ""
+      ).asJava
+      , Map(
+        "id" -> "future"
+        , "icon" -> ""
+      ).asJava
+    ).asJava
+  )
+  val appWithTestRedis = FakeApplication(additionalConfiguration = testRedis ++ testTracks)
 
   val sampleProposalType = ConferenceDescriptor.ConferenceProposalTypes
 
@@ -350,7 +364,7 @@ class ProposalSpecs extends PlaySpecification {
       "summary",
       "private message",
       sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
+      Track.UNKNOWN.id,
       Option("beginner"),
       userGroup = None)
 
@@ -380,7 +394,7 @@ class ProposalSpecs extends PlaySpecification {
     }
 
     val proposalId = "TST-001333"
-     val keepProposal = Proposal.validateNewProposal(Some(proposalId),
+    val keepProposal = Proposal.validateNewProposal(Some(proposalId),
       "fr",
       "test proposal deleted",
       None,
@@ -390,7 +404,7 @@ class ProposalSpecs extends PlaySpecification {
       "summary",
       "private message",
       sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
+      Track.UNKNOWN.id,
       Option("beginner"),
       userGroup = None)
 
@@ -412,19 +426,23 @@ class ProposalSpecs extends PlaySpecification {
     }
 
     val proposalId = "TST-001333"
-     val keepProposal = Proposal.validateNewProposal(Some(proposalId),
+    val keepProposal = Proposal(
+      proposalId,
+      "test event",
       "fr",
       "test proposal deleted",
+      "no_main_speaker",
       None,
       Nil,
-      sampleProposalType.CONF.id,
+      sampleProposalType.CONF,
       "audience level",
       "summary",
       "private message",
-      sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
-      Option("beginner"),
-      userGroup = None)
+      ProposalState.UNKNOWN,
+      track = Track.UNKNOWN,
+      demoLevel = Option("beginner"),
+      userGroup = None
+    )
 
     Proposal.save("user_1234", keepProposal, ProposalState.DRAFT)
 
@@ -444,7 +462,7 @@ class ProposalSpecs extends PlaySpecification {
     }
 
     val proposalId = "TST-001333"
-     val keepProposal = Proposal.validateNewProposal(Some(proposalId),
+    val keepProposal = Proposal.validateNewProposal(Some(proposalId),
       "fr",
       "test proposal deleted",
       None,
@@ -454,7 +472,7 @@ class ProposalSpecs extends PlaySpecification {
       "summary",
       "private message",
       sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
+      Track.UNKNOWN.id,
       Option("beginner"),
       userGroup = None)
 
@@ -478,7 +496,7 @@ class ProposalSpecs extends PlaySpecification {
 
     // 1-
     val proposalIdToDelete = "DEL-001333"
-     val proposalToDelete = Proposal.validateNewProposal(Some(proposalIdToDelete),
+    val proposalToDelete = Proposal.validateNewProposal(Some(proposalIdToDelete),
       "fr",
       "test proposal deleted",
       None,
@@ -488,7 +506,7 @@ class ProposalSpecs extends PlaySpecification {
       "summary",
       "private message",
       sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
+      Track.UNKNOWN.id,
       Option("beginner"),
       userGroup = None)
 
@@ -496,7 +514,7 @@ class ProposalSpecs extends PlaySpecification {
 
     // 2-
     val proposalIdToArchive = "ARC-001333"
-     val archivedProposal = Proposal.validateNewProposal(Some(proposalIdToArchive),
+    val archivedProposal = Proposal.validateNewProposal(Some(proposalIdToArchive),
       "fr",
       "test proposal archive",
       None,
@@ -506,7 +524,7 @@ class ProposalSpecs extends PlaySpecification {
       "summary",
       "private message",
       sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
+      Track.UNKNOWN.id,
       Option("beginner"),
       userGroup = None)
 
@@ -514,7 +532,7 @@ class ProposalSpecs extends PlaySpecification {
 
     // 3-
     val proposalId = "OK-001333"
-     val someProposal = Proposal.validateNewProposal(Some(proposalId),
+    val someProposal = Proposal.validateNewProposal(Some(proposalId),
       "fr",
       "some Proposal",
       None,
@@ -524,7 +542,7 @@ class ProposalSpecs extends PlaySpecification {
       "summary",
       "private message",
       sponsorTalk = false,
-      ConferenceDescriptor.ConferenceTracks.UNKNOWN.id,
+      Track.UNKNOWN.id,
       Option("beginner"),
       userGroup = None)
 

--- a/test/models/ReviewSpecs.scala
+++ b/test/models/ReviewSpecs.scala
@@ -24,10 +24,11 @@
 package models
 
 import library.Redis
+import models.Review._
 import org.apache.commons.lang3.RandomStringUtils
 import org.joda.time.DateTime
 import org.specs2.control.Debug
-import play.api.test.{FakeApplication, WithApplication, PlaySpecification}
+import play.api.test.{FakeApplication, PlaySpecification, WithApplication}
 
 /**
  * Review test for LUA.
@@ -36,7 +37,7 @@ import play.api.test.{FakeApplication, WithApplication, PlaySpecification}
 class ReviewSpecs extends PlaySpecification with Debug {
 
   // Use a different Redis Database than the PROD one
-  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6364", "redis.activeDatabase" -> 1)
+  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6363", "redis.activeDatabase" -> 1)
 
   // To avoid Play Cache Exception during tests, check this
   // https://groups.google.com/forum/#!topic/play-framework/PBIfeiwl5rU
@@ -307,18 +308,13 @@ class ReviewSpecs extends PlaySpecification with Debug {
 
       checkedProposal mustEqual(proposalId)
 
-      val score = scoreAndTotalVotes._1
-      val voters = scoreAndTotalVotes._2
-      val abstentions = scoreAndTotalVotes._3
-      val average = scoreAndTotalVotes._4
-      val standardDev = scoreAndTotalVotes._5
-
-      score mustEqual 15
-      average mustEqual 7.5
-      voters mustEqual 2
-      abstentions mustEqual 1
-      standardDev mustEqual 3.536
-
+      scoreAndTotalVotes mustEqual((
+        new Score(15),
+        new TotalVoter(2),
+        new TotalAbst(1),
+        new AverageNote(7.5),
+        new StandardDev(3.536)
+      ))
     }
 
   "should load the LUA script and not crash if a proposal has no votes"  in new WithApplication(app = appWithTestRedis()) {
@@ -402,18 +398,13 @@ class ReviewSpecs extends PlaySpecification with Debug {
 
       checkedProposal mustEqual(proposalId)
 
-      val score = scoreAndTotalVotes._1
-      val voters = scoreAndTotalVotes._2
-      val abstentions = scoreAndTotalVotes._3
-      val average = scoreAndTotalVotes._4
-      val standardDev = scoreAndTotalVotes._5
-
-      score mustEqual 0
-      average mustEqual 0
-      voters mustEqual 0
-      abstentions mustEqual 2
-      standardDev mustEqual 0
-
+      scoreAndTotalVotes mustEqual((
+        new Score(0),
+        new TotalVoter(0),
+        new TotalAbst(2),
+        new AverageNote(0),
+        new StandardDev(0)
+      ))
     }
 
   }

--- a/test/models/WebuserSpecs.scala
+++ b/test/models/WebuserSpecs.scala
@@ -32,7 +32,7 @@ import org.apache.commons.lang3.RandomStringUtils
  */
 class WebuserSpecs extends PlaySpecification {
 
-  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6364")
+  val testRedis = Map("redis.host" -> "localhost", "redis.port" -> "6363")
 
   // To avoid Play Cache Exception during tests, check this
   // https://groups.google.com/forum/#!topic/play-framework/PBIfeiwl5rU

--- a/test/models/WishlistSpecs.scala
+++ b/test/models/WishlistSpecs.scala
@@ -25,7 +25,7 @@ package models
 
 import play.api.test.{WithApplication, FakeApplication, PlaySpecification}
 import org.apache.commons.lang3.RandomStringUtils
-
+import WishlistSpecs._
 
 /**
  * Simple Spec2 functional test for Wishlist.
@@ -36,74 +36,97 @@ class WishlistSpecs extends PlaySpecification {
   // Just use a new redis instance for testing. Of course, do not use FLUSHDB ;-)
   val redisTestServer = Map(
     "redis.host" -> "localhost"
-    , "redis.port" -> "6364"
+    , "redis.port" -> "6363"
   )
 
   val appWithTestRedis = () => FakeApplication(additionalConfiguration = redisTestServer)
 
-    "A RequestToTalk" should {
+  "A RequestToTalk" should {
 
-      "be created and deleted" in new WithApplication(app = appWithTestRedis()) {
+    "be created and deleted" in new WithApplication(app = appWithTestRedis()) {
 
-        val testId = Some(RandomStringUtils.randomAlphabetic(4))
-        RequestToTalk.findById(testId.get) must beNone
+      val testId = Some(RandomStringUtils.randomAlphabetic(4))
+      RequestToTalk.findById(testId.get) must beNone
 
-        val requestToTalk = RequestToTalk.validateRequestToTalk(testId, "note", Some("message"), Some("speakerEmail"), "speakerName", "company", "java", false, "France", RequestToTalkStatus.UNKNOWN.code)
+      val requestToTalk = validateRequestToTalk(testId, "note", Some("message"), RequestToTalkStatus.UNKNOWN)
 
-        RequestToTalk.save("test", requestToTalk)
-        RequestToTalk.findById(testId.get) must beSome[RequestToTalk]
+      RequestToTalk.save("test", requestToTalk)
+      RequestToTalk.findById(testId.get) must beSome[RequestToTalk]
 
-        // Delete
-        RequestToTalk.delete("test", testId.get)
-        RequestToTalk.findById(testId.get) must beNone
-      }
-
-      "have a requestToTalk status" in new WithApplication(app = appWithTestRedis()) {
-
-        val testId = Some(RandomStringUtils.randomAlphabetic(4))
-        RequestToTalk.findById(testId.get) must beNone
-
-        val requestToTalk = RequestToTalk.validateRequestToTalk(testId, "noteStatustest", None, Some("speakerEmail"), "speakerName", "company", "java", false, "France", RequestToTalkStatus.CONTACTED.code)
-        RequestToTalk.save("test", requestToTalk)
-        val maybeRequest = RequestToTalkStatus.findCurrentStatus(testId.get)
-
-        maybeRequest.code must beEqualTo(RequestToTalkStatus.CONTACTED.code)
-
-
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.ACCEPTED.code)
-        RequestToTalkStatus.findCurrentStatus(testId.get).code must beEqualTo(RequestToTalkStatus.ACCEPTED.code)
-
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.DECLINED.code)
-        RequestToTalkStatus.findCurrentStatus(testId.get).code must beEqualTo(RequestToTalkStatus.DECLINED.code)
-
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.UNKNOWN.code) 
-        RequestToTalkStatus.findCurrentStatus(testId.get).code must beEqualTo(RequestToTalkStatus.UNKNOWN.code)
-
-      }
-
-      "returns a valid history" in new WithApplication(app = appWithTestRedis()) {
-
-        val testId = Some(RandomStringUtils.randomAlphabetic(4))
-        RequestToTalk.findById(testId.get) must beNone
-
-        val requestToTalk = RequestToTalk.validateRequestToTalk(testId, "note2", Some("message2"), Some("speakerEmail"), "speakerName", "company", "java", false, "France", RequestToTalkStatus.CONTACTED.code)
-
-        RequestToTalk.save("test", requestToTalk)
-
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.ACCEPTED.code)
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.DECLINED.code)
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.UNKNOWN.code)
-        RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.ACCEPTED.code)
-
-        val requestHistoryList = RequestToTalkStatus.history(testId.get)
-
-        // Assert
-        requestHistoryList must not have size(0)
-        requestHistoryList must have size 5
-        requestHistoryList.head.statusCode mustEqual RequestToTalkStatus.ACCEPTED.code
-        requestHistoryList.last.statusCode mustEqual RequestToTalkStatus.CONTACTED.code
-
-      }
+      // Delete
+      RequestToTalk.delete("test", testId.get)
+      RequestToTalk.findById(testId.get) must beNone
     }
+
+    "have a requestToTalk status" in new WithApplication(app = appWithTestRedis()) {
+
+      val testId = Some(RandomStringUtils.randomAlphabetic(4))
+      RequestToTalk.findById(testId.get) must beNone
+
+      val requestToTalk = validateRequestToTalk(testId, "noteStatustest", None, RequestToTalkStatus.CONTACTED)
+      RequestToTalk.save("test", requestToTalk)
+      val maybeRequest = RequestToTalkStatus.findCurrentStatus(testId.get)
+
+      maybeRequest.code must beEqualTo(RequestToTalkStatus.CONTACTED.code)
+
+
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.ACCEPTED.code)
+      RequestToTalkStatus.findCurrentStatus(testId.get).code must beEqualTo(RequestToTalkStatus.ACCEPTED.code)
+
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.DECLINED.code)
+      RequestToTalkStatus.findCurrentStatus(testId.get).code must beEqualTo(RequestToTalkStatus.DECLINED.code)
+
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.UNKNOWN.code)
+      RequestToTalkStatus.findCurrentStatus(testId.get).code must beEqualTo(RequestToTalkStatus.UNKNOWN.code)
+
+    }
+
+    "returns a valid history" in new WithApplication(app = appWithTestRedis()) {
+
+      val testId = Some(RandomStringUtils.randomAlphabetic(4))
+      RequestToTalk.findById(testId.get) must beNone
+
+      val requestToTalk = validateRequestToTalk(testId, "note2", Some("message2"), RequestToTalkStatus.CONTACTED)
+
+      RequestToTalk.save("test", requestToTalk)
+
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.ACCEPTED.code)
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.DECLINED.code)
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.UNKNOWN.code)
+      RequestToTalkStatus.changeStatus("test", testId.get, RequestToTalkStatus.ACCEPTED.code)
+
+      val requestHistoryList = RequestToTalkStatus.history(testId.get)
+
+      // Assert
+      requestHistoryList must not have size(0)
+      requestHistoryList must have size 5
+      requestHistoryList.head.statusCode mustEqual RequestToTalkStatus.ACCEPTED.code
+      requestHistoryList.last.statusCode mustEqual RequestToTalkStatus.CONTACTED.code
+
+    }
+  }
+
+}
+
+object WishlistSpecs {
+
+  private def validateRequestToTalk(id: Option[String],
+                                    note: String,
+                                    message: Option[String],
+                                    status: RequestToTalkStatus) =
+    RequestToTalk.validateRequestToTalk(
+      id,
+      note,
+      message,
+      Some("speakerEmail"),
+      "speakerName",
+      "company",
+      "java",
+      travel = false,
+      "France",
+      status.code,
+      None
+    )
+
 }
 


### PR DESCRIPTION
Fixed compilation issues and failing tests in specs.

Tests will now pass if specs are run individually and if a redis database is listening at `localhost:6363`. Nevertheless, they will fail if run all together since everything relies on a shared Redis singleton.

Maybe setting `parallelExecution in Test := false` would be enough but I did not figured out how to do this in a `Build.scala` file instead of a `build.sbt` file. I tried:
```
val main = play.Project(appName, appVersion, appDependencies).settings(
    resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
    , scalacOptions ++= Seq("-Xmax-classfile-name", "100") // add "-feature" to the Seq to have more details,
    , parallelExecution := false
  )
```
But it did not worked.